### PR TITLE
User can retrieve commit history formatted as <subject> <hash>

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "test": "jest",
     "test:coverage": "jest --coverage"
   },
-  "transform": {
-    "^.+\\.tsx?$": "ts-jest"
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    }
   },
   "devDependencies": {
     "@types/jest": "^24.0.15",

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -1,0 +1,11 @@
+export default class Commit {
+  private details: String;
+
+  constructor(details: String) {
+    this.details = details;
+  }
+
+  public getDetails() {
+    return this.details;
+  }
+}

--- a/src/commitLog.ts
+++ b/src/commitLog.ts
@@ -1,0 +1,15 @@
+import { execSync } from "child_process";
+
+export class CommitLog {
+  private commits: Array<any>;
+
+  constructor() {
+    const logBuffer = execSync(`git log --pretty=format:"%s %h"`);
+    const logString = logBuffer.toString();
+    this.commits = logString.split("\n");
+  }
+
+  public getCommits(): Array<any> {
+    return this.commits;
+  }
+}

--- a/src/commitLog.ts
+++ b/src/commitLog.ts
@@ -1,15 +1,16 @@
+import Commit from "./commit";
 import { execSync } from "child_process";
 
-export class CommitLog {
-  private commits: Array<any>;
+export default class CommitLog {
+  private commits: Array<Commit>;
 
   constructor() {
-    const logBuffer = execSync(`git log --pretty=format:"%s %h"`);
-    const logString = logBuffer.toString();
-    this.commits = logString.split("\n");
+    const logBuffer: Buffer = execSync(`git log --pretty=format:"%s %h"`);
+    const logString: String = logBuffer.toString();
+    this.commits = logString.split("\n").map(commit => new Commit(commit));
   }
 
-  public getCommits(): Array<any> {
+  public getCommits(): Array<Commit> {
     return this.commits;
   }
 }

--- a/test/feature.test.ts
+++ b/test/feature.test.ts
@@ -1,3 +1,20 @@
+import { CommitLog } from "../src/commitLog";
+const child_process = require("child_process");
+
 describe("Feature Tests", () => {
-  test("A single test to check Travis and CodeClimate intergration", () => {});
+  test("User can retrieve commit log", () => {
+    const expected = [
+      "feat: device serial getter 90010eb",
+      "feat: device name getter and setter 90010eb"
+    ];
+
+    const expectedString = expected.toString().replace(",", "\n");
+    const buffer = Buffer.from(expectedString);
+    child_process.execSync = jest.fn(() => buffer);
+
+    const commitLog = new CommitLog();
+
+    const actual = commitLog.getCommits();
+    expect(actual).toEqual(expected);
+  });
 });

--- a/test/feature.test.ts
+++ b/test/feature.test.ts
@@ -1,20 +1,24 @@
-import { CommitLog } from "../src/commitLog";
-const child_process = require("child_process");
+import CommitLog from "../src/commitLog";
+
+import ActualCommitFormatter from "./lib/actualCommitFormatter";
+import StubExecSyncGitLog from "./lib/stubExecSyncGitLog";
+const testData = require("./lib/data");
 
 describe("Feature Tests", () => {
   test("User can retrieve commit log", () => {
-    const expected = [
-      "feat: device serial getter 90010eb",
-      "feat: device name getter and setter 90010eb"
-    ];
+    const expected = {
+      first: testData.commits.first,
+      second: testData.commits.second
+    };
 
-    const expectedString = expected.toString().replace(",", "\n");
-    const buffer = Buffer.from(expectedString);
-    child_process.execSync = jest.fn(() => buffer);
+    StubExecSyncGitLog.stubCommits(expected);
 
     const commitLog = new CommitLog();
 
-    const actual = commitLog.getCommits();
-    expect(actual).toEqual(expected);
+    const actualCommits = commitLog.getCommits();
+    const actual = ActualCommitFormatter.format(actualCommits);
+
+    expect(actual.first).toEqual(expected.first);
+    expect(actual.second).toEqual(expected.second);
   });
 });

--- a/test/lib/actualCommitFormatter.ts
+++ b/test/lib/actualCommitFormatter.ts
@@ -1,0 +1,8 @@
+export default class ActualCommitFormatter {
+  static format(commits) {
+    return {
+      first: commits[0].getDetails(),
+      second: commits[1].getDetails()
+    };
+  }
+}

--- a/test/lib/data.json
+++ b/test/lib/data.json
@@ -1,0 +1,8 @@
+{
+  "commits": {
+    "first": "feat: option to hide device serial 4e179e4",
+    "second": "fix: retrieve device name correctly c4a49e1",
+    "third": "feat: device serial getter 90010eb",
+    "fourth": "feat: device name getter and setter 90010eb"
+  }
+}

--- a/test/lib/stubExecSyncGitLog.ts
+++ b/test/lib/stubExecSyncGitLog.ts
@@ -1,0 +1,22 @@
+const child_process = require("child_process");
+
+export default class StubExecSyncGitLog {
+  static stubCommits(commits) {
+    commits = this.prepareCommitsForBuffer(commits);
+
+    const buffer = Buffer.from(commits);
+    child_process.execSync = jest.fn(() => buffer);
+  }
+
+  private static prepareCommitsForBuffer(commits) {
+    commits = this.objectToArray(commits);
+    return this.formatToMatchGitLog(commits);
+  }
+  private static objectToArray(object) {
+    return Object.values(object);
+  }
+
+  private static formatToMatchGitLog(commits) {
+    return commits.toString().replace(",", "\n");
+  }
+}

--- a/test/unit/commit.test.ts
+++ b/test/unit/commit.test.ts
@@ -1,0 +1,23 @@
+import Commit from "../../src/commit";
+
+describe("Commit", () => {
+  describe("#getDetails", () => {
+    test("returns 'feat: device serial getter 90010eb'", () => {
+      const expected = "feat: device serial getter 90010eb";
+
+      const commit = new Commit("feat: device serial getter 90010eb");
+      const actual = commit.getDetails();
+
+      expect(actual).toEqual(expected);
+    });
+
+    test("returns 'feat: device name getter and setter 90010eb'", () => {
+      const expected = "feat: device name getter and setter 90010eb";
+
+      const commit = new Commit("feat: device name getter and setter 90010eb");
+      const actual = commit.getDetails();
+
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/test/unit/commitLog.test.ts
+++ b/test/unit/commitLog.test.ts
@@ -1,0 +1,36 @@
+import { CommitLog } from "../../src/commitLog";
+const child_process = require("child_process");
+
+describe("CommitLog", () => {
+  test("returns expected commits", () => {
+    const expected = [
+      "feat: option to hide device serial 4e179e4",
+      "fix: retrieve device name correctly c4a49e1"
+    ];
+
+    const expectedString = expected.toString().replace(",", "\n");
+    const buffer = Buffer.from(expectedString);
+    child_process.execSync = jest.fn(() => buffer);
+
+    const commitLog = new CommitLog();
+
+    const actual = commitLog.getCommits();
+    expect(actual).toEqual(expected);
+  });
+
+  test("returns expected commits", () => {
+    const expected = [
+      "feat: device serial getter 90010eb",
+      "feat: device name getter and setter 90010eb"
+    ];
+
+    const expectedString = expected.toString().replace(",", "\n");
+    const buffer = Buffer.from(expectedString);
+    child_process.execSync = jest.fn(() => buffer);
+
+    const commitLog = new CommitLog();
+
+    const actual = commitLog.getCommits();
+    expect(actual).toEqual(expected);
+  });
+});

--- a/test/unit/commitLog.test.ts
+++ b/test/unit/commitLog.test.ts
@@ -1,36 +1,41 @@
-import { CommitLog } from "../../src/commitLog";
-const child_process = require("child_process");
+import CommitLog from "../../src/commitLog";
+
+import ActualCommitFormatter from "../lib/actualCommitFormatter";
+import StubExecSyncGitLog from "../lib/stubExecSyncGitLog";
+const testData = require("../lib/data");
 
 describe("CommitLog", () => {
   test("returns expected commits", () => {
-    const expected = [
-      "feat: option to hide device serial 4e179e4",
-      "fix: retrieve device name correctly c4a49e1"
-    ];
+    const expected = {
+      first: testData.commits.first,
+      second: testData.commits.second
+    };
 
-    const expectedString = expected.toString().replace(",", "\n");
-    const buffer = Buffer.from(expectedString);
-    child_process.execSync = jest.fn(() => buffer);
+    StubExecSyncGitLog.stubCommits(expected);
 
     const commitLog = new CommitLog();
 
-    const actual = commitLog.getCommits();
-    expect(actual).toEqual(expected);
+    const actualCommits = commitLog.getCommits();
+    const actual = ActualCommitFormatter.format(actualCommits);
+
+    expect(actual.first).toEqual(expected.first);
+    expect(actual.second).toEqual(expected.second);
   });
 
   test("returns expected commits", () => {
-    const expected = [
-      "feat: device serial getter 90010eb",
-      "feat: device name getter and setter 90010eb"
-    ];
+    const expected = {
+      first: testData.commits.third,
+      second: testData.commits.fourth
+    };
 
-    const expectedString = expected.toString().replace(",", "\n");
-    const buffer = Buffer.from(expectedString);
-    child_process.execSync = jest.fn(() => buffer);
+    StubExecSyncGitLog.stubCommits(expected);
 
     const commitLog = new CommitLog();
 
-    const actual = commitLog.getCommits();
-    expect(actual).toEqual(expected);
+    const actualCommits = commitLog.getCommits();
+    const actual = ActualCommitFormatter.format(actualCommits);
+
+    expect(actual.first).toEqual(expected.first);
+    expect(actual.second).toEqual(expected.second);
   });
 });


### PR DESCRIPTION
User can now retrieve commit history formatted as `<subject> <hash>`.

This is made possible by having `CommitLog`, which stores an `Array` of `Commit`s'.

Closes #4 