### PR TITLE
Save log to file

### DIFF
--- a/src/commit.ts
+++ b/src/commit.ts
@@ -5,7 +5,7 @@ export default class Commit {
     this.details = details;
   }
 
-  public getDetails() {
+  public getDetails(): String {
     return this.details;
   }
 }

--- a/src/commitLog.ts
+++ b/src/commitLog.ts
@@ -5,12 +5,29 @@ export default class CommitLog {
   private commits: Array<Commit>;
 
   constructor() {
-    const logBuffer: Buffer = execSync(`git log --pretty=format:"%s %h"`);
-    const logString: String = logBuffer.toString();
-    this.commits = logString.split("\n").map(commit => new Commit(commit));
+    const log: String = this.getGitLog();
+    this.commits = this.parseCommits(log);
   }
 
   public getCommits(): Array<Commit> {
     return this.commits;
+  }
+
+  private getGitLog(): String {
+    const logBuffer: Buffer = this.execSync();
+    return logBuffer.toString();
+  }
+
+  private execSync(): Buffer {
+    return execSync(`git log --pretty=format:"%s %h"`);
+  }
+
+  private parseCommits(log: String): Array<Commit> {
+    const commits = log.split("\n");
+    return commits.map(this.createCommit);
+  }
+
+  private createCommit(commit: String): Commit {
+    return new Commit(commit);
   }
 }

--- a/src/fileSystem.ts
+++ b/src/fileSystem.ts
@@ -1,0 +1,8 @@
+const fs = require("fs");
+
+export default class FileSystem {
+  static create(filename: String, content: String): Boolean {
+    fs.writeFileSync(filename, content);
+    return true;
+  }
+}

--- a/test/feature.test.ts
+++ b/test/feature.test.ts
@@ -1,8 +1,12 @@
 import CommitLog from "../src/commitLog";
+import FileSystem from "../src/fileSystem";
 
 import ActualCommitFormatter from "./lib/actualCommitFormatter";
 import StubExecSyncGitLog from "./lib/stubExecSyncGitLog";
+import { conditionalExpression } from "@babel/types";
 const testData = require("./lib/data");
+
+const fs = require("fs");
 
 describe("Feature Tests", () => {
   test("User can retrieve commit log", () => {
@@ -20,5 +24,25 @@ describe("Feature Tests", () => {
 
     expect(actual.first).toEqual(expected.first);
     expect(actual.second).toEqual(expected.second);
+  });
+
+  test("User can save commits to a file", () => {
+    const stubbedCommits = {
+      first: testData.commits.first,
+      second: testData.commits.second
+    };
+
+    StubExecSyncGitLog.stubCommits(stubbedCommits);
+
+    const commitLog = new CommitLog();
+    const commits = commitLog.getCommits();
+
+    let content = "";
+    commits.forEach(commit => (content += commit.getDetails() + "\n"));
+
+    fs.writeFileSync = jest.fn();
+    FileSystem.create("CHANGELOG.md", content);
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith("CHANGELOG.md", content);
   });
 });

--- a/test/unit/fileSystem.test.ts
+++ b/test/unit/fileSystem.test.ts
@@ -1,0 +1,18 @@
+import FileSystem from "../../src/fileSystem";
+const fs = require("fs");
+
+describe("FileSystem", () => {
+  describe("#create", () => {
+    test("calls fs with 'CHANGELOG.md' and 'feat: device name getter and setter 90010eb'", () => {
+      fs.writeFileSync = jest.fn();
+
+      const filename = "CHANGELOG.md";
+      const content = "feat: device name getter and setter 90010eb";
+
+      const fileCreated = FileSystem.create(filename, content);
+
+      expect(fileCreated).toBe(true);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(filename, content);
+    });
+  });
+});


### PR DESCRIPTION
Closes #6 

Created `FileSystem`, which has a `static` method `create`. It takes `filename` and `content` as params, then uses `fs.writeFileSync` to create the file.

Since `fs.writeFileSync` does not return anything, `.create` returns `true`. This is because of the file creation fails, a runtime error will be thrown.