### PR TITLE
Fix edge case where commit subject has substring of commit types

### DIFF
--- a/src/changelogFormatter.ts
+++ b/src/changelogFormatter.ts
@@ -12,7 +12,7 @@ export default class ChangelogFormatter {
   }
 
   private static getFeatureCommits(commits): Array<Commit> {
-    return commits.filter(commit => commit.getDetails().includes("feat"));
+    return commits.filter(commit => commit.getDetails().match(/^feat/));
   }
 
   private static formatAddedSection(commits): string {
@@ -21,7 +21,7 @@ export default class ChangelogFormatter {
   }
 
   private static getFixCommits(commits): Array<Commit> {
-    return commits.filter(commit => commit.getDetails().includes("fix"));
+    return commits.filter(commit => commit.getDetails().match(/^fix/));
   }
 
   private static formatFixedSection(commits): string {

--- a/test/unit/changelogFormatter.test.ts
+++ b/test/unit/changelogFormatter.test.ts
@@ -64,5 +64,23 @@ describe("ChangeLog Formatter", () => {
 
       expect(actual).toEqual(expected);
     });
+
+    describe("When commits subjects have substrings that match commit types", () => {
+      test("categorise 'feat: changelogs have added and fixed sections d5ad74a' as Added", () => {
+        const commits = [
+          {
+            getDetails: () =>
+              "feat: changelogs have added and fixed sections d5ad74a"
+          }
+        ];
+        const actual = ChangelogFormatter.format(commits);
+
+        const expected =
+          "## Added\n\n" +
+          "- feat: changelogs have added and fixed sections d5ad74a\n";
+
+        expect(actual).toContain(expected);
+      });
+    });
   });
 });


### PR DESCRIPTION
For example, `feat: changelogs have added and fixed sections d5ad74a` has a substring `fix`, which was causing it to be filtered into the `## Fixed` section.

Inside `ChangelogMatcher`, instead of using `String.prototype.includes`, I used `String.prototype.match`. This lets you use a regex, setup to only look at the start of commit subjects.